### PR TITLE
basic pose recognition for presentation

### DIFF
--- a/src/super-mario-motion/gui.py
+++ b/src/super-mario-motion/gui.py
@@ -118,6 +118,7 @@ def init():
 
 # set_webcam_image and set_pose_image are supposed to be called in the update-loop in main.py
 def set_webcam_image(array):
+    array = array[:, ::-1, :]   # flip the camera horizontally only for the user
     image = ImageTk.PhotoImage(Image.fromarray(array).resize((webcam_image_width, webcam_image_height), Image.LANCZOS))
     label_webcam.config(image=image)
     label_webcam.image = image

--- a/src/super-mario-motion/vision.py
+++ b/src/super-mario-motion/vision.py
@@ -58,7 +58,6 @@ def cam_loop():
             if not ret:
                 break
 
-            image = cv.flip(image, 1)  # flips the camera horizontally
             rgb = cv.cvtColor(image, cv.COLOR_BGR2RGB)
             results = pose.process(rgb)
             frame = cv.cvtColor(image, cv.COLOR_RGB2BGR)


### PR DESCRIPTION
Resolves: Issue #8, #9, #11

Added two helper functions to get the coordinates of a landmark and the angle between 3 landmarks. These can be used to make processing movements and poses easier, angles being more robust than coordinates. 

Added recognition for the basic pose "right fist up" for presentation purposes, which is triggered by putting the right fist above the right shoulder.

Fixed a bug where the camera was flipped for the user, which might be confusing.

Fixed a Bug where the camera was flipped before processing it, which made the landmarks also recognized as flipped.