### PR TITLE
Make camera thread daemon and remove unused `exitApp` variable.

### DIFF
--- a/src/super-mario-motion/main.py
+++ b/src/super-mario-motion/main.py
@@ -43,4 +43,3 @@ if __name__ == '__main__':
 
     gui.window.after(0, update)
     gui.window.mainloop()
-    vision.exitApp = True

--- a/src/super-mario-motion/vision.py
+++ b/src/super-mario-motion/vision.py
@@ -10,7 +10,6 @@ import numpy as np
 skeleton_only_frame = None
 raw_frame = None
 skel_frame = None
-exitApp = False
 current_pose = "standing"
 lm_string = ""
 
@@ -58,7 +57,7 @@ def init():
     if not cam.isOpened():
         raise IOError("Cannot open camera")
     print("cam opened")
-    thread = threading.Thread(target=cam_loop)
+    thread = threading.Thread(target=cam_loop, daemon=True)
     thread.start()
 
 
@@ -159,9 +158,6 @@ def cam_loop():
                     if (x+1) % 4 == 0:
                         lm_string_temp += "\n"
                 lm_string = lm_string_temp
-
-            if exitApp:
-                break
 
     cam.release()
 


### PR DESCRIPTION
Resolves Issue #14.

We found a much easier way to close a thread when we close the gui window via the daemon argument. The bug that we thought this argument created was related to another error when no camera is connected. So this basically replaces PR #15.