### PR TITLE
Disable the button when paths are not valid

### DIFF
--- a/src/super_mario_motion/game_launcher.py
+++ b/src/super_mario_motion/game_launcher.py
@@ -6,12 +6,13 @@ exe, core = None, None
 
 module_log_prefix = "[Launcher]"
 
-config_retroarch_path = ("/Users/timobarton/Library/Application "
-                         "Support/Steam/steamapps/common/RetroArch")
-config_rom_path = (f"/Users/timobarton/Library/Application "
-                   f"Support/Steam/steamapps/common/RetroArch/downloads"
-                   f"/Super Mario Bros. ("
-                   f"World).nes")
+config_retroarch_path = (
+    "/mnt/files/SteamLibrary/steamapps/common/RetroArch/"
+    )
+
+config_rom_path = (
+    f"/mnt/files/roms/nes/Super Mario Bros. (World).nes"
+    )
 
 retroarch_path = Path(config_retroarch_path)
 rom_path = Path(config_rom_path)
@@ -33,9 +34,6 @@ def validate_path(path):
 
 validate_path(rom_path)
 validate_path(retroarch_path)
-
-def get_paths_valid():
-    return all_paths_valid
 
 def get_command(platform_):
     global exe, core

--- a/src/super_mario_motion/gui.py
+++ b/src/super_mario_motion/gui.py
@@ -176,7 +176,11 @@ def init():
         column=0,
         sticky="nsew")
 
-    button_launch_game.state(["disabled"])
+    # This button will be disabled if the paths
+    # defined in game_launcher are invalid
+    if not game_launcher.all_paths_valid:
+        button_launch_game.state(["disabled"])
+
 
     # Button "Help"
     button_help = ttk.Button(


### PR DESCRIPTION
When the program is started it checks for the path of retroarch and the path of the romfile. The button will disable (turning gray and become unclickable), if either one of the paths is invalid.
| Paths incorrectly set | Paths correctly set |
|-------------------------|---------------------|
|<img width="325" height="388" alt="image" src="https://github.com/user-attachments/assets/dd3ac2c6-bb03-4c70-8757-80ad669536e9" />|<img width="325" height="388" alt="image" src="https://github.com/user-attachments/assets/7b0a2348-dfec-416f-9b62-bde43d624a29" />|
