### PR TITLE
changed run-win.bat to python >= 3.12.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "super-mario-motion"
+version = "0.1.0"
+description = "Pose-controlled Super Mario Motion project"
+requires-python = ">=3.12"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/run-win.bat
+++ b/run-win.bat
@@ -27,6 +27,7 @@ pip install -r requirements.txt
 
 REM Run package module, not src
 echo Starting application...
+pip install -e .
 python -m super_mario_motion.main
 
 pause


### PR DESCRIPTION
Resolves: Issue #132 

The `run-win.bat` now checks for the correct python version 3.12.10 or 3.12.11.