### PR TITLE
tweaked parameters to balance stability and responsiveness

### DIFF
--- a/src/super_mario_motion/settings.py
+++ b/src/super_mario_motion/settings.py
@@ -13,7 +13,7 @@ class Settings:
     swim_interval = 0.25
 
     # vision_ml
-    ml_majority_vote = 7
-    frame_quality = 0.6
-    p_thresh = 0.75
-    vote_ratio = 0.6
+    ml_majority_vote = 3
+    frame_quality = 0.4
+    p_thresh = 0.65
+    vote_ratio = 0.55


### PR DESCRIPTION
Resolves: Issue #186 

I tuned the following parameters for better responsiveness. Now, jumping is almost instant, but the other inputs are delayed.
```python
    ml_majority_vote = 7
    frame_quality = 0.6
    p_thresh = 0.75
    vote_ratio = 0.6
```