### PR TITLE
[HOTFIX] Increase the duration the jump button is held

### DIFF
--- a/src/super_mario_motion/input.py
+++ b/src/super_mario_motion/input.py
@@ -225,7 +225,7 @@ def press_designated_input(pose_):
         case "jumping":
             _key_down(jump)
             _key_down(last_orientation)
-            time.sleep(0.1)
+            time.sleep(0.5)
             _key_up(last_orientation)
             _key_up(jump)
         case "running_right":


### PR DESCRIPTION
Resolves Issue #199 

I changed the jump button hold time from `0.1` to `0.5` seconds.

Please try to check if it works now, also try if it impacts full-body mode.